### PR TITLE
Specify the expected involvement of team members

### DIFF
--- a/working_group_charter.html
+++ b/working_group_charter.html
@@ -72,14 +72,14 @@
 
 
     <main>
-      <h1 id="title"><i class="todo">PROPOSED</i> Entity Reconciliation Working Group Charter</h1>
+      <h1 id="title"><i class="todo">PROPOSED</i> Entity Reconciliation  Group Charter</h1>
       <!-- delete PROPOSED after AC review completed -->
 
-      <p class="mission">The <strong>mission</strong> of the <a href="">Entity Reconciliation Working Group</a> is to develop a protocol for entity reconciliation on the Web. This process, also known as entity linking or entity resolution, involves identifying and linking entities across different datasets.</p>
+      <p class="mission">The <strong>mission</strong> of the <a href="">Entity Reconciliation  Group</a> is to develop a protocol for entity reconciliation on the Web. This process, also known as entity linking or entity resolution, involves identifying and linking entities across different datasets.</p>
       <!-- the link to the group is ALWAYS that available from https://www.w3.org/groups/wg or https://www.w3.org/groups/ig because each group page can then point to a different homepage, but not the other way around. -->
 
       <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/groups/wg/reconciliation/join">Join the Entity Reconciliation Working Group.</a></p>
+        <p class="join"><a href="https://www.w3.org/groups/wg/reconciliation/join">Join the Entity Reconciliation  Group.</a></p>
       </div>
 
          <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
@@ -315,7 +315,6 @@
         </h2>
         <p>
           To be successful, this Working Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the Working Group. There is no minimum requirement for other Participants.
-          <span class='todo'>Mention: The expected time commitment and level of involvement by the Team, see https://www.w3.org/2021/Process-20211102/#WGCharter</span>
         </p>
         <p>
           The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.


### PR DESCRIPTION
It seems that the existing paragraph already specifies the expected involvement of the team, so I propose to just remove this remaining TODO item.